### PR TITLE
ci(tests): remove constraints on poetry install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
+          pipx install poetry
           poetry --version
 
       - name: Install Nox


### PR DESCRIPTION
The constraints parameter did not work with Windows, specifically:

```bash
pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry
```