### PR TITLE
build: use rtx for dev setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,15 +7,10 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+  - id: check-added-large-files
 
 - repo: local
   hooks:
-
-  - id: check-added-large-files
-    name: Check for added large files
-    stages: [commit]
-    entry: check-added-large-files
-    language: system
 
   - id: ruff_format
     name: ruff_format

--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,0 +1,2 @@
+[tools]
+python = { version = "3.11", virtualenv = ".venv" }

--- a/README.rst
+++ b/README.rst
@@ -122,12 +122,42 @@ This program was developed during my master thesis. For a more detailed explanat
 the mathematical derivations and an analysis of the numerical precision of the program,
 please refer to the thesis found at `munin.uit.no`_.
 
+Contributing
+^^^^^^^^^^^^
+
+To contribute to the project, clone and install the full development version (uses
+poetry_ for dependencies). There is also a `.rtx.toml` file that installs and sets up
+an appropriate virtual environment if rtx_ is available on
+your system (it's really good, check it out!).
+
+.. code:: console
+
+    $ git clone https://github.com/engeir/inscar.git
+    $ cd inscar
+    $ # Set up a virtual environment, for example with rtx
+    $ rtx i
+    $ poetry install
+    $ pre-commit install
+
+Before committing new changes to a branch you may run command
+
+.. code:: console
+
+    $ nox
+
+to run the full test suite. You will need Poetry_, nox_ and nox-poetry_ installed for
+this.
+
 .. _Hagfors (1961): https://agupubs.onlinelibrary.wiley.com/doi/epdf/10.1029/JZ066i006p01699
 .. _Mace (2003): https://aip.scitation.org/doi/pdf/10.1063/1.1570828
-.. _munin.uit.no: https://hdl.handle.net/10037/19542
 .. _PyPI: https://pypi.org/
-.. _pip: https://pip.pypa.io/
 .. _assets: https://github.com/engeir/inscar/tree/main/assets
+.. _munin.uit.no: https://hdl.handle.net/10037/19542
+.. _nox-poetry: https://nox-poetry.readthedocs.io/
+.. _nox: https://nox.thea.codes/en/stable/
+.. _pip: https://pip.pypa.io/
+.. _poetry: https://python-poetry.org
+.. _rtx: https://github.com/jdx/rtx
 .. github-only
 .. _Contributor Guide: CONTRIBUTING.rst
 .. _Modules: https://inscar.readthedocs.io/en/latest/modules.html

--- a/README.rst
+++ b/README.rst
@@ -116,14 +116,14 @@ particle velocity distribution (default is ``VdfMaxwell``). An example showing h
 ``Vdf`` class can be made is given in assets_ (``VdfRealData``).
 
 Aside
-^^^^^
+-----
 
 This program was developed during my master thesis. For a more detailed explanation of
 the mathematical derivations and an analysis of the numerical precision of the program,
 please refer to the thesis found at `munin.uit.no`_.
 
 Contributing
-^^^^^^^^^^^^
+------------
 
 To contribute to the project, clone and install the full development version (uses
 poetry_ for dependencies). There is also a `.rtx.toml` file that installs and sets up


### PR DESCRIPTION
Adds a `.rtx.toml` config file that specifies the most recently supported python version and that automatically sets up a virtualenv, provided the user has [rtx](https://github.com/jdx/rtx) is installed.